### PR TITLE
Added previews to image autocomplete inputs

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -293,8 +293,20 @@ export default class App extends React.Component {
   }
 
   updateIcons(baseUrl) {
-    downloadSpriteMetadata(baseUrl, icons => {
-      this.setState({ spec: updateRootSpec(this.state.spec, 'sprite', icons)})
+    downloadSpriteMetadata(baseUrl, metadata => {
+      const {spec} = this.state;
+      this.setState({
+        spec: {
+          ...spec,
+          $root: {
+            ...spec.$root,
+            sprite: {
+              ...spec.$root["sprite"],
+              metadata: metadata
+            }
+          }
+        }
+      })
     })
   }
 

--- a/src/components/InputSpec.jsx
+++ b/src/components/InputSpec.jsx
@@ -12,6 +12,7 @@ import InputDynamicArray from './InputDynamicArray'
 import InputFont from './InputFont'
 import InputAutocomplete from './InputAutocomplete'
 import InputEnum from './InputEnum'
+import SpriteIcon from './SpriteIcon'
 import capitalize from 'lodash.capitalize'
 
 const iconProperties = ['background-pattern', 'fill-pattern', 'line-pattern', 'fill-extrusion-pattern', 'icon-image']
@@ -85,10 +86,21 @@ export default class SpecField extends React.Component {
         case 'formatted':
         case 'string':
           if (iconProperties.indexOf(this.props.fieldName) >= 0) {
-            const options = this.props.fieldSpec.values || [];
+            const {metadata} = this.props.fieldSpec;
+            const options = Object.entries(metadata && metadata.data ? metadata.data : {});
             return <InputAutocomplete
               {...commonProps}
-              options={options.map(f => [f, f])}
+              options={options.map(([k,v]) => {
+                return [
+                  k,
+                  <SpriteIcon
+                    metadata={metadata}
+                    maxWidth={120}
+                    id={k}
+                    data={v}
+                  />
+                ];
+              })}
             />
           } else {
             return <InputString

--- a/src/components/PropertyGroup.jsx
+++ b/src/components/PropertyGroup.jsx
@@ -13,7 +13,7 @@ function getFieldSpec(spec, layerType, fieldName) {
   if(iconProperties.indexOf(fieldName) >= 0) {
     return {
       ...fieldSpec,
-      values: spec.$root.sprite.values
+      metadata: spec.$root.sprite.metadata
     }
   }
   if(fieldName === 'text-font') {

--- a/src/components/SpriteIcon.jsx
+++ b/src/components/SpriteIcon.jsx
@@ -1,0 +1,57 @@
+import React from 'react'
+
+export default function SpriteIcon (props) {
+  const {metadata, id, data, maxWidth} = props;
+  const {image} = metadata;
+  const pixelRatio = Math.max(window.devicePixelRatio, 2);
+
+  function getUrls (pixelRatio, url) {
+    const out = [];
+    for (var i=pixelRatio; i>=1; i--) {
+      if (i > 1) {
+        out.push(
+          url.replace(/.png/, `@${i}x.png`)
+        );
+      }
+      else {
+        out.push(url);
+      }
+    }
+
+    return out.map(url => {
+      return `url(${url})`;
+    }).join(", ");
+  }
+
+  let scale = 1;
+  if (data.width > maxWidth) {
+    scale = maxWidth/data.width;
+  }
+
+  const spriteWidth = image.width * scale;
+  const spriteHeight = image.height * scale;
+  const width = data.width * scale;
+  const height = data.height * scale;
+  const x = data.x * scale;
+  const y = data.y * scale;
+
+  return <div className="maputnik-sprite-icon">
+    <div className="maputnik-sprite-icon__text">
+      {id}
+    </div>
+    {image &&
+      <div className="maputnik-sprite-icon__icon">
+        <div
+          style={{
+            width: width,
+            height: height,
+            backgroundImage: getUrls(pixelRatio, metadata.imageUrl),
+            backgroundSize: `${spriteWidth}px ${spriteHeight}px`,
+            backgroundPosition: `${-x}px ${-y}px`
+          }}
+        />
+      </div>
+    }
+  </div>
+}
+

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -167,3 +167,18 @@
   }
 }
 
+.maputnik-sprite-icon {
+  display: flex;
+}
+
+.maputnik-sprite-icon__text {
+  flex: 1;
+}
+
+.maputnik-sprite-icon__icon {
+  margin-left: 0.6em;
+  padding: 2px;
+  background-color: white;
+  background-size: 8px 8px;
+  background-position: 0 0, 4px 4px;
+}


### PR DESCRIPTION
Added a nice preview of the sprites in the image autocomplete 

<img width="362" alt="Screenshot 2020-09-16 at 14 29 21" src="https://user-images.githubusercontent.com/235915/93344256-5a446200-f829-11ea-9979-dee12ea2bf99.png">

Note: Max width of `120px` for the preview image, incase there is a large image in the sprite, will scale the image preview if larger.

@pathmapper I'm going to leave this as in draft for now, I think we should resolve #711 and push out a new release first before merging.
