### PR TITLE
Only store revisions that include style changes

### DIFF
--- a/src/libs/revisions.js
+++ b/src/libs/revisions.js
@@ -1,3 +1,5 @@
+import {diff} from '@mapbox/mapbox-gl-style-spec'
+
 export class RevisionStore {
   constructor(initialRevisions=[]) {
     this.revisions = initialRevisions
@@ -13,10 +15,17 @@ export class RevisionStore {
   }
 
   addRevision(revision) {
-    //TODO: compare new revision style id with old ones
-    //and ensure that it is always the same id
-    this.revisions.push(revision)
-    this.currentIdx++
+    // only store revision if has changes
+    const changes = diff(revision, this.current);
+    if (changes.length > 0) {
+
+      // clear any "redo" revisions once a change is made
+      // and ensure current index is at end of list
+      this.revisions = this.revisions.slice(0, this.currentIdx + 1);
+
+      this.revisions.push(revision)
+      this.currentIdx++
+    }
   }
 
   undo() {


### PR DESCRIPTION
Similar to issue https://github.com/maputnik/editor/issues/753, I've run into some odd behavior when trying undo/redo recent changes.

I've been using this change in a local fork, and it's seemed to be running pretty well. The main logic changes are:
* Only store a revision if there is a style diff
  * so you don't need to "undo" no-op changes
* Clear the "redo" revisions once an addition is made
  * without this change, things are _pushed_ to the end of the list, even though the currentIndex may have been decremented (I suspect this is the main bug)