### PR TITLE
Update MapLibre to version 4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maputnik",
-  "version": "2.0.0-pre.2",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maputnik",
-      "version": "2.0.0-pre.2",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@mapbox/mapbox-gl-rtl-text": "^0.2.3",
@@ -33,7 +33,7 @@
         "lodash.isequal": "^4.5.0",
         "lodash.throttle": "^4.1.1",
         "mapbox-gl-inspect": "^1.3.1",
-        "maplibre-gl": "^4.0.0-pre.4",
+        "maplibre-gl": "^4.0.0",
         "maputnik-design": "github:maputnik/design#172b06c",
         "ol": "^6.14.1",
         "ol-mapbox-style": "^7.1.1",
@@ -9531,9 +9531,9 @@
       "integrity": "sha512-f+NBjJJY4T3dHtlEz1wCG7YFlkODEjFIYlxDdLIDMNpkSksqTt+l/d4rjuwItxuzkuMFvPyrjzV2lxRM4ePcIA=="
     },
     "node_modules/maplibre-gl": {
-      "version": "4.0.0-pre.4",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.0.0-pre.4.tgz",
-      "integrity": "sha512-rY+8cqyFHEKrKPyxTSqBXb4B3VwEefKfyUPy9j6zUaG2dcvIWmDR/+YU8Y6FHv+Hq3GET1ubMnvyKlVwvRbsJg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.0.0.tgz",
+      "integrity": "sha512-bzVQ2pdOWITwbE+JHKSiAB/viVBBx4Aa1puydc1xizOWGbvRHD9pXpy3dsaW2ZlbmZKbv9r9sHpcvM9fTLGsKA==",
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
@@ -9542,7 +9542,7 @@
         "@mapbox/unitbezier": "^0.0.1",
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^20.0.0",
+        "@maplibre/maplibre-gl-style-spec": "^20.1.0",
         "@types/geojson": "^7946.0.13",
         "@types/geojson-vt": "3.2.5",
         "@types/mapbox__point-geometry": "^0.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maputnik",
-  "version": "2.0.0-pre.2",
+  "version": "2.0.0",
   "description": "A MapLibre GL visual style editor",
   "type": "module",
   "main": "''",
@@ -44,7 +44,7 @@
     "lodash.isequal": "^4.5.0",
     "lodash.throttle": "^4.1.1",
     "mapbox-gl-inspect": "^1.3.1",
-    "maplibre-gl": "^4.0.0-pre.4",
+    "maplibre-gl": "^4.0.0",
     "maputnik-design": "github:maputnik/design#172b06c",
     "ol": "^6.14.1",
     "ol-mapbox-style": "^7.1.1",


### PR DESCRIPTION
This updates maplibre from a pre-release to an official release.
It also removed the pre.2 from maputnik as maputnik is now published and there's no reason to keep it in pre-release version name.
This doesn't mean maputnik has an npm package at this point though.