### PR TITLE
Readme.md container port changed to 80

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ targeted at developers and map designers.
 - In a Docker, run this command and browse to http://localhost:8888, Ctrl+C to stop the server.
 
 ```bash
-docker run -it --rm -p 8888:8888 ghcr.io/maplibre/maputnik:main
+docker run -it --rm -p 8888:80 ghcr.io/maplibre/maputnik:main
 ```
 
 ## Documentation


### PR DESCRIPTION
Activating maputnik with `docker run` requires to bind port 80 from container and not 8888, because nginx is running with default config and listening port 80

For `npm run` port 8888 is explicitly set up [in config](https://github.com/maplibre/maputnik/blob/bc5ecfade6801e16df339a8caba766d28b88de56/vite.config.ts#L8).