### PR TITLE
Upgrade Cypress to fix CI errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,7 @@
         "@types/uuid": "^9.0.8",
         "@vitejs/plugin-react": "^4.2.1",
         "cors": "^2.8.5",
-        "cypress": "^13.7.0",
+        "cypress": "^13.7.2",
         "eslint": "^8.57.0",
         "eslint-plugin-react": "^7.34.1",
         "eslint-plugin-react-hooks": "^4.6.0",
@@ -3749,9 +3749,9 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.7.0.tgz",
-      "integrity": "sha512-UimjRSJJYdTlvkChcdcfywKJ6tUYuwYuk/n1uMMglrvi+ZthNhoRYcxnWgTqUtkl17fXrPAsD5XT2rcQYN1xKA==",
+      "version": "13.7.3",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.7.3.tgz",
+      "integrity": "sha512-uoecY6FTCAuIEqLUYkTrxamDBjMHTYak/1O7jtgwboHiTnS1NaMOoR08KcTrbRZFCBvYOiS4tEkQRmsV+xcrag==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@types/uuid": "^9.0.8",
     "@vitejs/plugin-react": "^4.2.1",
     "cors": "^2.8.5",
-    "cypress": "^13.7.0",
+    "cypress": "^13.7.2",
     "eslint": "^8.57.0",
     "eslint-plugin-react": "^7.34.1",
     "eslint-plugin-react-hooks": "^4.6.0",


### PR DESCRIPTION
This upgrade should fix the error of Firefox tests failing. See this issue for more details:
https://github.com/cypress-io/cypress/issues/29190