### PR TITLE
Update feature id label to $id in feature properties popup

### DIFF
--- a/src/components/MapMaplibreGlFeaturePropertyPopup.tsx
+++ b/src/components/MapMaplibreGlFeaturePropertyPopup.tsx
@@ -28,7 +28,7 @@ function renderFeature(feature: InspectFeature, idx: number) {
       <td colSpan={2} className="maputnik-popup-layer-id">{feature.layer['source']}: {feature.layer['source-layer']}{feature.inspectModeCounter && <span> × {feature.inspectModeCounter}</span>}</td>
     </tr>
     {renderKeyValueTableRow("$type", feature.geometry.type)}
-    {renderKeyValueTableRow("Feature ID", displayValue(feature.id))}
+    {renderKeyValueTableRow("$id", displayValue(feature.id))}
     {Object.keys(feature.properties).map(propertyName => {
       const property = feature.properties[propertyName];
       return renderKeyValueTableRow(propertyName, displayValue(property))


### PR DESCRIPTION
Current label, "Feature ID", creates a little bit of confusion. It's not clear that this label isn't really part of the feature properties.

For example, when we want to filter by feature id, we need to use `$id`

```
[==, "$id," 123] 
```