### PR TITLE
Fix release-notes.js

### DIFF
--- a/build/release-notes.js
+++ b/build/release-notes.js
@@ -42,7 +42,7 @@ if (previous) {
 }
 const templatedReleaseNotes = `${header}
 
-${latest.changelog}
+${latest.changelog}`;
 
 // eslint-disable-next-line eol-last
 process.stdout.write(templatedReleaseNotes.trimEnd());


### PR DESCRIPTION
Was missing trailing `, causing [this failure](https://github.com/maplibre/maputnik/actions/runs/10619718712/job/29437920164)