### PR TITLE
add fallback behavior for `showOpenFilePicker` and `showSaveFilePicker`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Add scheme type options for vector/raster tile
 - Add `tileSize` field for raster and raster-dem tile sources
 - Update Protomaps Light gallery style to v4
-- Add support to edit local files on the file system
+- Add support to edit local files on the file system if supported by the browser
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/components/ModalExport.tsx
+++ b/src/components/ModalExport.tsx
@@ -86,6 +86,15 @@ class ModalExportInternal extends React.Component<ModalExportInternalProps> {
   async saveStyle() {
     const tokenStyle = this.tokenizedStyle();
 
+    // it is not guaranteed that the File System Access API is available on all
+    // browsers. If the function is not available, a fallback behavior is used.
+    if (typeof window.showSaveFilePicker !== "function") {
+      const blob = new Blob([tokenStyle], {type: "application/json;charset=utf-8"});
+      const exportName = this.exportName();
+      saveAs(blob, exportName + ".json");
+      return;
+    }
+
     let fileHandle = this.props.fileHandle;
     if (fileHandle == null) {
       fileHandle = await this.createFileHandle();
@@ -179,22 +188,18 @@ class ModalExportInternal extends React.Component<ModalExportInternalProps> {
         </div>
 
         <div className="maputnik-modal-export-buttons">
-          <InputButton
-            onClick={this.saveStyle.bind(this)}
-          >
+          <InputButton onClick={this.saveStyle.bind(this)}>
             <MdSave />
             {t("Save")}
           </InputButton>
-          <InputButton
-            onClick={this.saveStyleAs.bind(this)}
-          >
-            <MdSave />
-            {t("Save as")}
-          </InputButton>
+          {typeof window.showSaveFilePicker === "function" && (
+            <InputButton onClick={this.saveStyleAs.bind(this)}>
+              <MdSave />
+              {t("Save as")}
+            </InputButton>
+          )}
 
-          <InputButton
-            onClick={this.createHtml.bind(this)}
-          >
+          <InputButton onClick={this.createHtml.bind(this)}>
             <MdMap />
             {t("Create HTML")}
           </InputButton>

--- a/src/components/ModalExport.tsx
+++ b/src/components/ModalExport.tsx
@@ -123,10 +123,6 @@ class ModalExportInternal extends React.Component<ModalExportInternalProps> {
   }
 
   async createFileHandle(): Promise<FileSystemFileHandle | null> {
-    assert(
-      showSaveFilePickerAvailable,
-      'A file handle can only be created if window.showSaveFilePicker() is available as a function.'
-    )
     const pickerOpts: SaveFilePickerOptions = {
       types: [
         {

--- a/src/components/ModalExport.tsx
+++ b/src/components/ModalExport.tsx
@@ -5,7 +5,7 @@ import {version} from 'maplibre-gl/package.json'
 import {format} from '@maplibre/maplibre-gl-style-spec'
 import type {StyleSpecification} from 'maplibre-gl'
 import {MdMap, MdSave} from 'react-icons/md'
-import { WithTranslation, withTranslation } from 'react-i18next';
+import {WithTranslation, withTranslation} from 'react-i18next';
 
 import FieldString from './FieldString'
 import InputButton from './InputButton'
@@ -15,6 +15,7 @@ import fieldSpecAdditional from '../libs/field-spec-additional'
 
 
 const MAPLIBRE_GL_VERSION = version;
+const showSaveFilePickerAvailable = typeof window.showSaveFilePicker === "function";
 
 
 type ModalExportInternalProps = {
@@ -29,7 +30,7 @@ type ModalExportInternalProps = {
 
 class ModalExportInternal extends React.Component<ModalExportInternalProps> {
 
-  tokenizedStyle () {
+  tokenizedStyle() {
     return format(
       style.stripAccessTokens(
         style.replaceAccessTokens(this.props.mapStyle)
@@ -37,8 +38,8 @@ class ModalExportInternal extends React.Component<ModalExportInternalProps> {
     );
   }
 
-  exportName () {
-    if(this.props.mapStyle.name) {
+  exportName() {
+    if (this.props.mapStyle.name) {
       return Slugify(this.props.mapStyle.name, {
         replacement: '_',
         remove: /[*\-+~.()'"!:]/g,
@@ -88,7 +89,7 @@ class ModalExportInternal extends React.Component<ModalExportInternalProps> {
 
     // it is not guaranteed that the File System Access API is available on all
     // browsers. If the function is not available, a fallback behavior is used.
-    if (typeof window.showSaveFilePicker !== "function") {
+    if (!showSaveFilePickerAvailable) {
       const blob = new Blob([tokenStyle], {type: "application/json;charset=utf-8"});
       const exportName = this.exportName();
       saveAs(blob, exportName + ".json");
@@ -121,12 +122,16 @@ class ModalExportInternal extends React.Component<ModalExportInternalProps> {
     this.props.onOpenToggle();
   }
 
-  async createFileHandle() : Promise<FileSystemFileHandle | null> {
+  async createFileHandle(): Promise<FileSystemFileHandle | null> {
+    assert(
+      showSaveFilePickerAvailable,
+      'A file handle can only be created if window.showSaveFilePicker() is available as a function.'
+    )
     const pickerOpts: SaveFilePickerOptions = {
       types: [
         {
           description: "json",
-          accept: { "application/json": [".json"] },
+          accept: {"application/json": [".json"]},
         },
       ],
       suggestedName: this.exportName(),
@@ -189,18 +194,18 @@ class ModalExportInternal extends React.Component<ModalExportInternalProps> {
 
         <div className="maputnik-modal-export-buttons">
           <InputButton onClick={this.saveStyle.bind(this)}>
-            <MdSave />
+            <MdSave/>
             {t("Save")}
           </InputButton>
-          {typeof window.showSaveFilePicker === "function" && (
+          {showSaveFilePickerAvailable && (
             <InputButton onClick={this.saveStyleAs.bind(this)}>
-              <MdSave />
+              <MdSave/>
               {t("Save as")}
             </InputButton>
           )}
 
           <InputButton onClick={this.createHtml.bind(this)}>
-            <MdMap />
+            <MdMap/>
             {t("Create HTML")}
           </InputButton>
         </div>

--- a/src/components/ModalOpen.tsx
+++ b/src/components/ModalOpen.tsx
@@ -171,7 +171,7 @@ class ModalOpenInternal extends React.Component<ModalOpenInternalProps, ModalOpe
 
   // it is not guaranteed that the File System Access API is available on all
   // browsers. If the function is not available, a fallback behavior is used.
-  onUpload = async (_: any, files: Result[]) => {
+  onFileChanged = async (_: any, files: Result[]) => {
     const [, file] = files[0];
     const reader = new FileReader();
     this.clearError();
@@ -250,7 +250,7 @@ class ModalOpenInternal extends React.Component<ModalOpenInternalProps, ModalOpe
                   onClick={this.onOpenFile}><MdFileUpload/> {t("Open Style")}
                 </InputButton>
               ) : (
-                <FileReaderInput onChange={this.onUpload} tabIndex={-1} aria-label={t("Open Style")}>
+                <FileReaderInput onChange={this.onFileChanged} tabIndex={-1} aria-label={t("Open Style")}>
                   <InputButton className="maputnik-upload-button"><MdFileUpload /> {t("Open Style")}</InputButton>
                 </FileReaderInput>
               )}


### PR DESCRIPTION
## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [x] Briefly describe the changes in this PR.
 - [x] Link to related issues.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.

## Description

`showOpenFilePicker` and `showSaveFilePicker` are undefined on Firefox. With this pr, Maputnik uses the old behavior as a fallback. It keeps the naming "open" and "save" instead of "upload" and "download" to underline that the style stays within the browser and no actual upload happens.

@zstadler Could you give it a try, please?

## Related Issue

- fixes https://github.com/maplibre/maputnik/issues/966

## Visual Changes

The "Save as" button gets hidden if `showSaveFilePicker` is not available since it would have no use.

<table>
<tr>
<td>
Chrome
</td>
<td>
Firefox
</td>
</tr>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/cdc2cd4d-1c09-4dec-8c94-f8b0dd0c5b8e" />
</td>
<td>
<img src="https://github.com/user-attachments/assets/0763ef63-6501-4cc1-977b-94753c3008ae" />
</td>
</tr>
</table>