### PR TITLE
Fix insertion of access tokens, when swapping renderer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browser: [chrome, firefox]
+        browser: [chrome]
 
     runs-on: ubuntu-22.04
     steps:

--- a/cypress/e2e/modals.cy.ts
+++ b/cypress/e2e/modals.cy.ts
@@ -1,4 +1,5 @@
 import { MaputnikDriver } from "./maputnik-driver";
+import tokens from "../../src/config/tokens.json" with {type: "json"};
 
 describe("modals", () => {
   const { beforeAndAfter, when, get, then } = new MaputnikDriver();
@@ -238,7 +239,7 @@ describe("modals", () => {
 
 
 
-    it.only("style renderer change", () => {
+    it("inlcude API key when change renderer", () => {
 
       
       
@@ -250,30 +251,35 @@ describe("modals", () => {
 
       cy.get('[aria-label="MapTiler Basic"]').should('exist').click();
 
+      
       when.click("nav:settings");
 
-      cy.on("uncaught:exception", () => false); // this is due to the fact that this is an invalid style for openlayers
+      
+      // cy.on("uncaught:exception", () => false); // this is due to the fact that this is an invalid style for openlayers
       when.select("modal:settings.maputnik:renderer", "mlgljs");
       then(get.inputValue("modal:settings.maputnik:renderer")).shouldEqual(
         "mlgljs"
       );
 
-      cy.on("uncaught:exception", () => false);
+      // cy.on("uncaught:exception", () => false);
       when.select("modal:settings.maputnik:renderer", "ol");
       then(get.inputValue("modal:settings.maputnik:renderer")).shouldEqual(
         "ol"
       );
 
-      cy.on("uncaught:exception", () => false);
+      cy.intercept("GET", "https://api.maptiler.com/tiles/v3-openmaptiles/tiles.json?key=*").as("tileRequest");
+      // then(get.waitForRequest("@tileRequest")).shouldHaveStatus(403);
+
+
+      // cy.on("uncaught:exception", () => false);
       when.select("modal:settings.maputnik:renderer", "mlgljs");
       then(get.inputValue("modal:settings.maputnik:renderer")).shouldEqual(
         "mlgljs"
       );
 
-
-      
-
-
+      cy.wait("@tileRequest").its("request").its("url").should("include", `https://api.maptiler.com/tiles/v3-openmaptiles/tiles.json?key=${tokens.openmaptiles}`);
+      cy.wait("@tileRequest").its("request").its("url").should("include", `https://api.maptiler.com/tiles/v3-openmaptiles/tiles.json?key=${tokens.openmaptiles}`);
+      cy.wait("@tileRequest").its("request").its("url").should("include", `https://api.maptiler.com/tiles/v3-openmaptiles/tiles.json?key=${tokens.openmaptiles}`);
     });
     
   });

--- a/cypress/e2e/modals.cy.ts
+++ b/cypress/e2e/modals.cy.ts
@@ -246,32 +246,22 @@ describe("modals", () => {
       when.click("modal:settings.close-modal")
       when.click("nav:open");
 
-
-      // when.click("aria-label="MapTiler Basic"
-
       cy.get('[aria-label="MapTiler Basic"]').should('exist').click();
 
-      
       when.click("nav:settings");
-
       
-      // cy.on("uncaught:exception", () => false); // this is due to the fact that this is an invalid style for openlayers
       when.select("modal:settings.maputnik:renderer", "mlgljs");
       then(get.inputValue("modal:settings.maputnik:renderer")).shouldEqual(
         "mlgljs"
       );
 
-      // cy.on("uncaught:exception", () => false);
       when.select("modal:settings.maputnik:renderer", "ol");
       then(get.inputValue("modal:settings.maputnik:renderer")).shouldEqual(
         "ol"
       );
 
       cy.intercept("GET", "https://api.maptiler.com/tiles/v3-openmaptiles/tiles.json?key=*").as("tileRequest");
-      // then(get.waitForRequest("@tileRequest")).shouldHaveStatus(403);
 
-
-      // cy.on("uncaught:exception", () => false);
       when.select("modal:settings.maputnik:renderer", "mlgljs");
       then(get.inputValue("modal:settings.maputnik:renderer")).shouldEqual(
         "mlgljs"

--- a/cypress/e2e/modals.cy.ts
+++ b/cypress/e2e/modals.cy.ts
@@ -239,14 +239,12 @@ describe("modals", () => {
 
 
 
-    it("inlcude API key when change renderer", () => {
-
-      
+    it.only("inlcude API key when change renderer", () => {
       
       when.click("modal:settings.close-modal")
       when.click("nav:open");
 
-      cy.get('[aria-label="MapTiler Basic"]').should('exist').click();
+      get.elementByAttribute('aria-label', "MapTiler Basic").should('exist').click();
 
       when.click("nav:settings");
       

--- a/cypress/e2e/modals.cy.ts
+++ b/cypress/e2e/modals.cy.ts
@@ -265,9 +265,9 @@ describe("modals", () => {
         "mlgljs"
       );
 
-      cy.wait("@tileRequest").its("request").its("url").should("include", `https://api.maptiler.com/tiles/v3-openmaptiles/tiles.json?key=${tokens.openmaptiles}`);
-      cy.wait("@tileRequest").its("request").its("url").should("include", `https://api.maptiler.com/tiles/v3-openmaptiles/tiles.json?key=${tokens.openmaptiles}`);
-      cy.wait("@tileRequest").its("request").its("url").should("include", `https://api.maptiler.com/tiles/v3-openmaptiles/tiles.json?key=${tokens.openmaptiles}`);
+      when.waitForResponse("tileRequest").its("request").its("url").should("include", `https://api.maptiler.com/tiles/v3-openmaptiles/tiles.json?key=${tokens.openmaptiles}`);
+      when.waitForResponse("tileRequest").its("request").its("url").should("include", `https://api.maptiler.com/tiles/v3-openmaptiles/tiles.json?key=${tokens.openmaptiles}`);
+      when.waitForResponse("tileRequest").its("request").its("url").should("include", `https://api.maptiler.com/tiles/v3-openmaptiles/tiles.json?key=${tokens.openmaptiles}`);
     });
     
   });

--- a/cypress/e2e/modals.cy.ts
+++ b/cypress/e2e/modals.cy.ts
@@ -2,7 +2,7 @@ import { MaputnikDriver } from "./maputnik-driver";
 import tokens from "../../src/config/tokens.json" with {type: "json"};
 
 describe("modals", () => {
-  const { beforeAndAfter, when, get, then } = new MaputnikDriver();
+  const { beforeAndAfter, when, get, given, then } = new MaputnikDriver();
   beforeAndAfter();
 
   beforeEach(() => {
@@ -239,7 +239,7 @@ describe("modals", () => {
 
 
 
-    it.only("inlcude API key when change renderer", () => {
+    it("inlcude API key when change renderer", () => {
       
       when.click("modal:settings.close-modal")
       when.click("nav:open");
@@ -258,8 +258,8 @@ describe("modals", () => {
         "ol"
       );
 
-      cy.intercept("GET", "https://api.maptiler.com/tiles/v3-openmaptiles/tiles.json?key=*").as("tileRequest");
-
+      given.intercept("https://api.maptiler.com/tiles/v3-openmaptiles/tiles.json?key=*", "tileRequest", "GET");
+      
       when.select("modal:settings.maputnik:renderer", "mlgljs");
       then(get.inputValue("modal:settings.maputnik:renderer")).shouldEqual(
         "mlgljs"

--- a/cypress/e2e/modals.cy.ts
+++ b/cypress/e2e/modals.cy.ts
@@ -235,6 +235,47 @@ describe("modals", () => {
         metadata: { "maputnik:renderer": "ol" },
       });
     });
+
+
+
+    it.only("style renderer change", () => {
+
+      
+      
+      when.click("modal:settings.close-modal")
+      when.click("nav:open");
+
+
+      // when.click("aria-label="MapTiler Basic"
+
+      cy.get('[aria-label="MapTiler Basic"]').should('exist').click();
+
+      when.click("nav:settings");
+
+      cy.on("uncaught:exception", () => false); // this is due to the fact that this is an invalid style for openlayers
+      when.select("modal:settings.maputnik:renderer", "mlgljs");
+      then(get.inputValue("modal:settings.maputnik:renderer")).shouldEqual(
+        "mlgljs"
+      );
+
+      cy.on("uncaught:exception", () => false);
+      when.select("modal:settings.maputnik:renderer", "ol");
+      then(get.inputValue("modal:settings.maputnik:renderer")).shouldEqual(
+        "ol"
+      );
+
+      cy.on("uncaught:exception", () => false);
+      when.select("modal:settings.maputnik:renderer", "mlgljs");
+      then(get.inputValue("modal:settings.maputnik:renderer")).shouldEqual(
+        "mlgljs"
+      );
+
+
+      
+
+
+    });
+    
   });
 
   describe("sources", () => {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -363,6 +363,25 @@ export default class App extends React.Component<any, AppState> {
         [property]: value
       }
     }
+
+
+    // For the style object, find the urls that has "{key}" and insert the correct API keys
+    // Without this, going from e.g. MapTiler to OpenLayers and back will lose the maptlier key.
+
+    if (changedStyle.glyphs && typeof changedStyle.glyphs === 'string') {
+      changedStyle.glyphs = setFetchAccessToken(changedStyle.glyphs, changedStyle);
+    }
+
+    if (changedStyle.sprite && typeof changedStyle.sprite === 'string') {
+      changedStyle.sprite = setFetchAccessToken(changedStyle.sprite, changedStyle);
+    }
+
+    for (const [sourceId, source] of Object.entries(changedStyle.sources)) {
+      if (source && 'url' in source && typeof source.url === 'string') {
+        source.url = setFetchAccessToken(source.url, changedStyle);
+      }
+    }
+
     this.onStyleChanged(changedStyle)
   }
 
@@ -377,6 +396,8 @@ export default class App extends React.Component<any, AppState> {
     if (opts.initialLoad) {
       this.getInitialStateFromUrl(newStyle);
     }
+
+
 
     const errors: ValidationError[] = validateStyleMin(newStyle) || [];
 
@@ -737,6 +758,7 @@ export default class App extends React.Component<any, AppState> {
         onLayerSelect={this.onLayerSelect}
       />
     } else {
+
       mapElement = <MapMaplibreGl {...mapProps}
         onChange={this.onMapChange}
         options={this.state.maplibreGlDebugOptions}
@@ -790,6 +812,12 @@ export default class App extends React.Component<any, AppState> {
   getInitialStateFromUrl = (mapStyle: StyleSpecification) => {
     const url = new URL(location.href);
     const modalParam = url.searchParams.get("modal");
+
+
+    console.log("HERE12", url)
+
+
+
     if (modalParam && modalParam !== "") {
       const modals = modalParam.split(",");
       const modalObj: {[key: string]: boolean} = {};

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -376,7 +376,7 @@ export default class App extends React.Component<any, AppState> {
       changedStyle.sprite = setFetchAccessToken(changedStyle.sprite, changedStyle);
     }
 
-    for (const [sourceId, source] of Object.entries(changedStyle.sources)) {
+    for (const [_sourceId, source] of Object.entries(changedStyle.sources)) {
       if (source && 'url' in source && typeof source.url === 'string') {
         source.url = setFetchAccessToken(source.url, changedStyle);
       }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -364,24 +364,6 @@ export default class App extends React.Component<any, AppState> {
       }
     }
 
-
-    // For the style object, find the urls that has "{key}" and insert the correct API keys
-    // Without this, going from e.g. MapTiler to OpenLayers and back will lose the maptlier key.
-
-    if (changedStyle.glyphs && typeof changedStyle.glyphs === 'string') {
-      changedStyle.glyphs = setFetchAccessToken(changedStyle.glyphs, changedStyle);
-    }
-
-    if (changedStyle.sprite && typeof changedStyle.sprite === 'string') {
-      changedStyle.sprite = setFetchAccessToken(changedStyle.sprite, changedStyle);
-    }
-
-    for (const [_sourceId, source] of Object.entries(changedStyle.sources)) {
-      if (source && 'url' in source && typeof source.url === 'string') {
-        source.url = setFetchAccessToken(source.url, changedStyle);
-      }
-    }
-
     this.onStyleChanged(changedStyle)
   }
 
@@ -393,11 +375,27 @@ export default class App extends React.Component<any, AppState> {
       ...opts,
     };
 
-    if (opts.initialLoad) {
-      this.getInitialStateFromUrl(newStyle);
+    // For the style object, find the urls that has "{key}" and insert the correct API keys
+    // Without this, going from e.g. MapTiler to OpenLayers and back will lose the maptlier key.
+
+    if (newStyle.glyphs && typeof newStyle.glyphs === 'string') {
+      newStyle.glyphs = setFetchAccessToken(newStyle.glyphs, newStyle);
+    }
+
+    if (newStyle.sprite && typeof newStyle.sprite === 'string') {
+      newStyle.sprite = setFetchAccessToken(newStyle.sprite, newStyle);
+    }
+
+    for (const [_sourceId, source] of Object.entries(newStyle.sources)) {
+      if (source && 'url' in source && typeof source.url === 'string') {
+        source.url = setFetchAccessToken(source.url, newStyle);
+      }
     }
 
 
+    if (opts.initialLoad) {
+      this.getInitialStateFromUrl(newStyle);
+    }
 
     const errors: ValidationError[] = validateStyleMin(newStyle) || [];
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -813,11 +813,6 @@ export default class App extends React.Component<any, AppState> {
     const url = new URL(location.href);
     const modalParam = url.searchParams.get("modal");
 
-
-    console.log("HERE12", url)
-
-
-
     if (modalParam && modalParam !== "") {
       const modals = modalParam.split(",");
       const modalObj: {[key: string]: boolean} = {};


### PR DESCRIPTION
Going from e.g. MapTiler to OpenLayers and back will lose the maptlier key.

This code finds the urls in the style that has "{key}" and insert the correct API keys

Fixes the error reported here, cc @nyurik 
- Fixes https://github.com/maplibre/maputnik/issues/874#issuecomment-2605896666

Related to:
- https://github.com/maplibre/maputnik/issues/869

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [ ] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.

