### PR TITLE
fix: Multi choice options style regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main
 
 ### ✨ Features and improvements
+- Fix radio/delete filter buttons styling regression
 - Add german translation
 - Use same version number for web and desktop versions
 - Add scheme type options for vector/raster tile

--- a/src/components/FilterEditorBlock.tsx
+++ b/src/components/FilterEditorBlock.tsx
@@ -16,7 +16,7 @@ class FilterEditorBlockInternal extends React.Component<FilterEditorBlockInterna
       </div>
       <div className="maputnik-filter-editor-block-action">
         <InputButton
-          className="maputnik-delete-filter"
+          className="maputnik-icon-button"
           onClick={this.props.onDelete}
           title={t("Delete filter block")}
         >

--- a/src/components/InputMultiInput.tsx
+++ b/src/components/InputMultiInput.tsx
@@ -20,7 +20,7 @@ export default class InputMultiInput extends React.Component<InputMultiInputProp
     const radios = options.map(([val, label])=> {
       return <label
         key={val}
-        className={classnames("maputnik-radio-as-button", {"maputnik-button-selected": val === selectedValue})}
+        className={classnames("maputnik-button", "maputnik-radio-as-button", {"maputnik-button-selected": val === selectedValue})}
       >
         <input type="radio"
           name={this.props.name}

--- a/src/styles/_filtereditor.scss
+++ b/src/styles/_filtereditor.scss
@@ -55,10 +55,6 @@
   margin-top: vars.$margin-3;
 }
 
-.maputnik-delete-filter {
-  @extend .maputnik-icon-button !optional; /* stylelint-disable-line */
-}
-
 .maputnik-filter-editor-block {
   display: flex;
   column-gap: 6px;

--- a/src/styles/_filtereditor.scss
+++ b/src/styles/_filtereditor.scss
@@ -66,8 +66,6 @@
 }
 
 .maputnik-radio-as-button {
-  @extend .maputnik-button !optional; /* stylelint-disable-line */
-
   border: solid 1px transparent;
 
   &:focus-within {


### PR DESCRIPTION
## Launch Checklist


This PR fixes the silliness with the `maputnik-multibutton` requiring `maputnik-button` and `@extend` not working because not included in said file.

Fixes https://github.com/maplibre/maputnik/issues/1044

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/0f4cd7a3-0359-4d0f-aaca-b346739cb760) | ![image](https://github.com/user-attachments/assets/8b8f4aa4-b672-4495-9454-864d756799cc) |


This also fixes the same issue a few lines up where `maputnik-delete-filter` refers to an not imprted `@extend`.


 - [x] Write tests for all new functionality.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
