### PR TITLE
Move docker to node 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18 as builder
+FROM node:22 as builder
 WORKDIR /maputnik
 
 # Only copy package.json to prevent npm install from running on every build


### PR DESCRIPTION
This unblocks the CI

We already use node 22 in the CI most places, I just forgot the Dockerfile, and now that Node 18 is recently EOL it appear to be failing there.

## Launch Checklist

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->


 - [X] Briefly describe the changes in this PR.
 - [ ] Link to related issues.
 - [ ] Include before/after visuals or gifs if this PR includes visual changes.
 - [ ] Write tests for all new functionality.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section.
