### PR TITLE
Use different icons for different layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### ✨ Features and improvements
 - Added translation to "Links" in debug modal
 - Add support for hillshade's color arrays and relief-color elevation expression
+- Change layers icons to make them a bit more distinct
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/src/components/IconLayer.tsx
+++ b/src/components/IconLayer.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 
 import type {CSSProperties} from "react";
-import { BsDiamond, BsDiamondFill, BsFonts, BsSun } from "react-icons/bs";
-import { MdBubbleChart, MdOutlineCircle, MdPriorityHigh } from "react-icons/md";
+import { BsDiamondFill, BsFonts, BsSun } from "react-icons/bs";
+import { MdBubbleChart, MdOutlineCircle, MdOutlineStreetview, MdOutlineVerticalShades, MdPriorityHigh } from "react-icons/md";
 import { IoAnalyticsOutline } from "react-icons/io5";
+import { CiMountain1 } from "react-icons/ci";
 
 type IconLayerProps = {
   type: string
@@ -14,13 +15,13 @@ type IconLayerProps = {
 const IconLayer: React.FC<IconLayerProps> = (props) => {
   const iconProps = { style: props.style };
   switch(props.type) {
-    case "fill-extrusion": return <BsDiamondFill {...iconProps} />;
-    case "raster": return <BsDiamond {...iconProps} />;
+    case "fill-extrusion": return <MdOutlineVerticalShades {...iconProps} />;
+    case "raster": return <BsDiamondFill {...iconProps} />;
     case "hillshade": return <BsSun {...iconProps} />;
-    case "color-relief": return <MdBubbleChart {...iconProps} />;
-    case "heatmap": return <BsDiamond {...iconProps} />;
-    case "fill": return <BsDiamond {...iconProps} />;
-    case "background": return <BsDiamondFill {...iconProps} />;
+    case "color-relief": return <CiMountain1 {...iconProps} />;
+    case "heatmap": return <MdBubbleChart {...iconProps} />;
+    case "fill": return <BsDiamondFill {...iconProps} />;
+    case "background": return <MdOutlineStreetview {...iconProps} />;
     case "line": return <IoAnalyticsOutline {...iconProps} />;
     case "symbol": return <BsFonts {...iconProps} />;
     case "circle": return <MdOutlineCircle {...iconProps} />;


### PR DESCRIPTION
## Launch Checklist

This changes the layers icons a bit in order to make them a bit more distinct:

After:
<img width="580" height="331" alt="image" src="https://github.com/user-attachments/assets/f341a64e-0310-40f7-8f5a-650d7bb06b9f" />


 - [x] Briefly describe the changes in this PR.
 - [x] Include before/after visuals or gifs if this PR includes visual changes.
 - [x] Add an entry to `CHANGELOG.md` under the `## main` section.
