### PR TITLE
feat: display current open filename in header bar

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -121,6 +121,7 @@ type AppState = {
     codeEditor: boolean
   }
   fileHandle: FileSystemFileHandle | null
+  currentFileName?: string
 };
 
 export default class App extends React.Component<any, AppState> {
@@ -170,6 +171,7 @@ export default class App extends React.Component<any, AppState> {
         debugToolbox: false,
       },
       fileHandle: null,
+      currentFileName: undefined,
     };
 
     this.layerWatcher = new LayerWatcher({
@@ -611,8 +613,8 @@ export default class App extends React.Component<any, AppState> {
     }
   };
 
-  openStyle = (styleObj: StyleSpecificationWithId, fileHandle: FileSystemFileHandle | null) => {
-    this.setState({fileHandle: fileHandle});
+  openStyle = (styleObj: StyleSpecificationWithId, fileHandle: FileSystemFileHandle | null, currentFileName?: string) => {
+    this.setState({fileHandle: fileHandle, currentFileName});
     styleObj = this.setDefaultValues(styleObj);
     this.onStyleChanged(styleObj);
   };
@@ -849,6 +851,10 @@ export default class App extends React.Component<any, AppState> {
     this.setState({ fileHandle });
   };
 
+  onSetCurrentFileName = (currentFileName?: string) => {
+    this.setState({ currentFileName });
+  };
+
   onChangeOpenlayersDebug = (key: keyof AppState["openlayersDebugOptions"], value: boolean) => {
     this.setState({
       openlayersDebugOptions: {
@@ -877,6 +883,7 @@ export default class App extends React.Component<any, AppState> {
       mapStyle={this.state.mapStyle}
       inspectModeEnabled={this.state.mapState === "inspect"}
       sources={this.state.sources}
+      currentFileName={this.state.currentFileName}
       onStyleChanged={this.onStyleChanged}
       onStyleOpen={this.onStyleChanged}
       onSetMapState={this.setMapState}
@@ -959,6 +966,7 @@ export default class App extends React.Component<any, AppState> {
         onOpenToggle={() => this.toggleModal("export")}
         fileHandle={this.state.fileHandle}
         onSetFileHandle={this.onSetFileHandle}
+        onSetCurrentFileName={this.onSetCurrentFileName}
       />
       <ModalOpen
         isOpen={this.state.isOpen.open}

--- a/src/components/AppToolbar.tsx
+++ b/src/components/AppToolbar.tsx
@@ -221,11 +221,6 @@ class AppToolbarInternal extends React.Component<AppToolbarInternalProps> {
               <span className="maputnik-toolbar-version">v{pkgJson.version}</span>
             </h1>
           </a>
-          {this.props.currentFileName && (
-            <span className="maputnik-toolbar-filename" title={this.props.currentFileName}>
-              {this.props.currentFileName}
-            </span>
-          )}
         </div>
         <div className="maputnik-toolbar__actions" role="navigation" aria-label="Toolbar">
           <ToolbarAction wdKey="nav:open" onClick={() => this.props.onToggleModal("open")}>
@@ -284,12 +279,13 @@ class AppToolbarInternal extends React.Component<AppToolbarInternalProps> {
 
           <ToolbarSelect wdKey="nav:language">
             <MdLanguage />
-            <IconText>Language
+            <div className="maputnik-toolbar-lang-file">
               <select
-                className="maputnik-select"
+                className="maputnik-select maputnik-select--compact"
                 data-wd-key="maputnik-lang-select"
                 onChange={(e) => this.handleLanguageChange(e.target.value)}
                 value={this.props.i18n.language}
+                aria-label={t("Language")}
               >
                 {Object.entries(supportedLanguages).map(([code, name]) => {
                   return (
@@ -299,7 +295,13 @@ class AppToolbarInternal extends React.Component<AppToolbarInternalProps> {
                   );
                 })}
               </select>
-            </IconText>
+
+              {this.props.currentFileName && (
+                <span className="maputnik-toolbar-filename" title={this.props.currentFileName}>
+                  {this.props.currentFileName}
+                </span>
+              )}
+            </div>
           </ToolbarSelect>
 
           <ToolbarLink href={"https://github.com/maplibre/maputnik/wiki"}>

--- a/src/components/AppToolbar.tsx
+++ b/src/components/AppToolbar.tsx
@@ -99,6 +99,7 @@ type AppToolbarInternalProps = {
   onStyleChanged: OnStyleChangedCallback
   // A new style has been uploaded
   onStyleOpen: OnStyleChangedCallback
+  currentFileName?: string
   // A dict of source id's and the available source layers
   sources: object
   children?: React.ReactNode
@@ -220,6 +221,11 @@ class AppToolbarInternal extends React.Component<AppToolbarInternalProps> {
               <span className="maputnik-toolbar-version">v{pkgJson.version}</span>
             </h1>
           </a>
+          {this.props.currentFileName && (
+            <span className="maputnik-toolbar-filename" title={this.props.currentFileName}>
+              {this.props.currentFileName}
+            </span>
+          )}
         </div>
         <div className="maputnik-toolbar__actions" role="navigation" aria-label="Toolbar">
           <ToolbarAction wdKey="nav:open" onClick={() => this.props.onToggleModal("open")}>

--- a/src/components/modals/ModalExport.tsx
+++ b/src/components/modals/ModalExport.tsx
@@ -24,6 +24,7 @@ type ModalExportInternalProps = {
   isOpen: boolean
   onOpenToggle(): void
   onSetFileHandle(fileHandle: FileSystemFileHandle | null): unknown
+  onSetCurrentFileName(fileName?: string): unknown
   fileHandle: FileSystemFileHandle | null
 } & WithTranslation;
 
@@ -92,7 +93,9 @@ class ModalExportInternal extends React.Component<ModalExportInternalProps> {
     if (!showSaveFilePickerAvailable) {
       const blob = new Blob([tokenStyle], {type: "application/json;charset=utf-8"});
       const exportName = this.exportName();
-      saveAs(blob, exportName + ".json");
+      const fileName = exportName + ".json";
+      saveAs(blob, fileName);
+      this.props.onSetCurrentFileName(fileName);
       return;
     }
 
@@ -106,6 +109,7 @@ class ModalExportInternal extends React.Component<ModalExportInternalProps> {
     const writable = await fileHandle.createWritable();
     await writable.write(tokenStyle);
     await writable.close();
+    this.props.onSetCurrentFileName(fileHandle.name);
     this.props.onOpenToggle();
   }
 
@@ -119,6 +123,7 @@ class ModalExportInternal extends React.Component<ModalExportInternalProps> {
     const writable = await fileHandle.createWritable();
     await writable.write(tokenStyle);
     await writable.close();
+    this.props.onSetCurrentFileName(fileHandle.name);
     this.props.onOpenToggle();
   }
 

--- a/src/components/modals/ModalOpen.tsx
+++ b/src/components/modals/ModalOpen.tsx
@@ -107,7 +107,7 @@ class ModalOpenInternal extends React.Component<ModalOpenInternalProps, ModalOpe
 
         const mapStyle = style.ensureStyleValidity(body);
         console.log("Loaded style ", mapStyle.id);
-        this.props.onStyleOpen(mapStyle);
+        this.props.onStyleOpen(mapStyle, null, undefined);
         this.onOpenToggle();
       })
       .catch((err) => {
@@ -163,7 +163,7 @@ class ModalOpenInternal extends React.Component<ModalOpenInternalProps, ModalOpe
     }
     mapStyle = style.ensureStyleValidity(mapStyle);
 
-    this.props.onStyleOpen(mapStyle, fileHandle);
+    this.props.onStyleOpen(mapStyle, fileHandle, file.name);
     this.onOpenToggle();
     return file;
   };
@@ -190,7 +190,7 @@ class ModalOpenInternal extends React.Component<ModalOpenInternalProps, ModalOpe
         return;
       }
       mapStyle = style.ensureStyleValidity(mapStyle);
-      this.props.onStyleOpen(mapStyle);
+      this.props.onStyleOpen(mapStyle, null, file.name);
       this.onOpenToggle();
     };
     reader.onerror = e => console.log(e.target);

--- a/src/styles/_toolbar.scss
+++ b/src/styles/_toolbar.scss
@@ -14,6 +14,9 @@
 
 .maputnik-toolbar-logo-container {
   position: relative;
+  display: flex;
+  align-items: center;
+  min-width: 0;
 }
 
 .maputnik-toolbar-logo {
@@ -92,6 +95,21 @@
   font-size: 10px;
   margin: 0 4px;
   white-space: nowrap;
+}
+
+.maputnik-toolbar-filename {
+  display: inline-flex;
+  align-items: center;
+  max-width: 260px;
+  margin-left: vars.$margin-2;
+  padding: 2px 8px;
+  border: 1px solid vars.$color-midgray;
+  border-radius: 4px;
+  color: vars.$color-white;
+  font-size: 11px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 
 .maputnik-toolbar-action {

--- a/src/styles/_toolbar.scss
+++ b/src/styles/_toolbar.scss
@@ -100,7 +100,7 @@
 .maputnik-toolbar-filename {
   display: inline-flex;
   align-items: center;
-  max-width: 260px;
+  max-width: 360px;
   margin-left: vars.$margin-2;
   padding: 2px 8px;
   border: 1px solid vars.$color-midgray;
@@ -110,6 +110,18 @@
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
+}
+
+.maputnik-toolbar-lang-file {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.maputnik-select--compact {
+  padding: 2px 6px;
+  font-size: 11px;
+  vertical-align: middle;
 }
 
 .maputnik-toolbar-action {


### PR DESCRIPTION
## Fix: Display current open filename in header bar

Closes #1541

---

### Problem

Maputnik has two separate concepts:
- **Style name** — stored in JSON as the `name` field and shown in Style Settings
- **File name** — actual JSON filename on disk (e.g. `map1_changed.json`)

Previously, when a style file was opened, the filename was not retained in app state. As a result, users with multiple tabs open (same style name, different files) could not tell which tab belonged to which file.

---

### Fix

Introduced a single `currentFileName` value in app state that is:
- Set when a local file is opened via the Open dialog
- Updated on Save and Save As
- Shown in the top header area as a read-only file indicator
- Hidden when no local file is associated (fresh unsaved style or URL-loaded style)

Style name behavior in Style Settings is completely unchanged.

---

### Screenshot

<img width="524" height="90" alt="image" src="https://github.com/user-attachments/assets/335bdee4-28ad-41e3-b766-8f2a1a6e35a8" />

> `map1.json` is now visible in the header bar, making it easy to identify which file is open in each tab.


---

### Files changed

| File | Change |
|---|---|
| `App.tsx` | Added `currentFileName` to `AppState`, initialized it, updated `openStyle()`, added `onSetCurrentFileName()`, wired props to toolbar and export modal |
| `ModalOpen.tsx` | Captures filename on local open paths and passes it to app state; URL-open keeps filename empty |
| `ModalExport.tsx` | Updates `currentFileName` on Save and Save As |
| `AppToolbar.tsx` | Renders read-only current filename indicator in header area |
| `_toolbar.scss` | Styling for filename indicator layout and visibility |

---

### Testing

- [x] Open a local JSON file — filename appears in header
- [x] Open two different local files in separate tabs — each tab shows its own filename
- [x] Save / Save As — header updates to the current filename
- [x] Fresh style (no local file loaded) — header shows no filename
- [x] URL-loaded style — header shows no filename
- [x] `npm run lint` passes
- [x] `npm run build` passes