### PR TITLE
feat: make editor sidebar resizable and add dismiss close button to b…

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -927,6 +927,7 @@ export class App extends React.Component<any, AppState> {
       mapStyle={this.state.mapStyle}
       errors={this.state.errors}
       infos={this.state.infos}
+      onClearInfos={() => this.setState({ infos: [] })}
     /> : undefined;
 
 

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -13,34 +13,84 @@ type AppLayoutInternalProps = {
   modals?: React.ReactNode
 } & WithTranslation;
 
-class AppLayoutInternal extends React.Component<AppLayoutInternalProps> {
+type AppLayoutInternalState = {
+  sidebarWidth: number
+  isResizing: boolean
+};
+
+class AppLayoutInternal extends React.Component<AppLayoutInternalProps, AppLayoutInternalState> {
+  constructor(props: AppLayoutInternalProps) {
+    super(props);
+    this.state = {
+      sidebarWidth: 350,
+      isResizing: false
+    };
+  }
+
+  componentWillUnmount() {
+    this.stopResizing();
+  }
+
+  startResizing = (e: React.MouseEvent) => {
+    e.preventDefault();
+    this.setState({ isResizing: true });
+    document.addEventListener("mousemove", this.resizeSidebar);
+    document.addEventListener("mouseup", this.stopResizing);
+  };
+
+  stopResizing = () => {
+    this.setState({ isResizing: false });
+    document.removeEventListener("mousemove", this.resizeSidebar);
+    document.removeEventListener("mouseup", this.stopResizing);
+  };
+
+  resizeSidebar = (e: MouseEvent) => {
+    const newWidth = Math.max(200, Math.min(e.clientX, window.innerWidth - 100));
+    this.setState({ sidebarWidth: newWidth });
+  };
 
   render() {
     document.body.dir = this.props.i18n.dir();
 
+    const hasDrawer = !!this.props.layerEditor;
+    const hasCodeEditor = !!this.props.codeEditor;
+    const showResizer = hasDrawer || hasCodeEditor;
+    const currentSidebarWidth = showResizer ? this.state.sidebarWidth : 200;
+
+    const layoutClassName = [
+      "maputnik-layout",
+      hasDrawer ? "maputnik-layout--has-drawer" : "",
+      hasCodeEditor ? "maputnik-layout--has-code-editor" : "",
+      this.state.isResizing ? "maputnik-layout--is-resizing" : ""
+    ].filter(Boolean).join(" ");
+
     return <IconContext.Provider value={{size: "14px"}}>
-      <div className="maputnik-layout">
+      <div className={layoutClassName}>
         {this.props.toolbar}
         <div className="maputnik-layout-main">
-          {this.props.codeEditor && <div className="maputnik-layout-code-editor">
-            <ScrollContainer>
-              {this.props.codeEditor}
-            </ScrollContainer>
-          </div>
-          }
-          {!this.props.codeEditor && <>
-            <div className="maputnik-layout-list">
-              {this.props.layerList}
-            </div>
-            <div className="maputnik-layout-drawer">
+          <div className="maputnik-layout-sidebar" style={{ width: currentSidebarWidth }}>
+            {this.props.codeEditor && <div className="maputnik-layout-code-editor">
               <ScrollContainer>
-                {this.props.layerEditor}
+                {this.props.codeEditor}
               </ScrollContainer>
             </div>
-          </>}
+            }
+            {!this.props.codeEditor && <>
+              <div className="maputnik-layout-list">
+                {this.props.layerList}
+              </div>
+              {this.props.layerEditor && <div className="maputnik-layout-drawer">
+                <ScrollContainer>
+                  {this.props.layerEditor}
+                </ScrollContainer>
+              </div>
+              }
+            </>}
+          </div>
+          {showResizer && <div className="maputnik-layout-resizer" onMouseDown={this.startResizing} />}
           {this.props.map}
         </div>
-        {this.props.bottom && <div className="maputnik-layout-bottom">
+        {this.props.bottom && <div className="maputnik-layout-bottom" style={{ left: currentSidebarWidth }}>
           {this.props.bottom}
         </div>
         }

--- a/src/components/AppMessagePanel.tsx
+++ b/src/components/AppMessagePanel.tsx
@@ -3,6 +3,7 @@ import { formatLayerId } from "../libs/format";
 import { type LayerSpecification, type StyleSpecification } from "maplibre-gl";
 import { type WithTranslation, withTranslation } from "react-i18next";
 import { type MappedError } from "../libs/definitions";
+import { MdClose } from "react-icons/md";
 
 type AppMessagePanelInternalProps = {
   errors?: MappedError[]
@@ -11,6 +12,7 @@ type AppMessagePanelInternalProps = {
   onLayerSelect?(index: number): void;
   currentLayer?: LayerSpecification
   selectedLayerIndex?: number
+  onClearInfos?(): void;
 } & WithTranslation;
 
 class AppMessagePanelInternal extends React.Component<AppMessagePanelInternalProps> {
@@ -54,9 +56,21 @@ class AppMessagePanelInternal extends React.Component<AppMessagePanelInternalPro
       return <p key={"info-" + i}>{m}</p>;
     });
 
+    const hasInfos = this.props.infos && this.props.infos.length > 0;
+
     return <div className="maputnik-message-panel">
       {errors}
       {infos}
+      {hasInfos && this.props.onClearInfos && (
+        <button
+          className="maputnik-message-panel__close"
+          onClick={this.props.onClearInfos}
+          title="Clear messages"
+          aria-label="Clear messages"
+        >
+          <MdClose size="16px" />
+        </button>
+      )}
     </div>;
   }
 }

--- a/src/components/InputColor.tsx
+++ b/src/components/InputColor.tsx
@@ -42,9 +42,10 @@ export class InputColor extends React.Component<InputColorProps> {
     const elem = this.colorInput;
     if(elem) {
       const pos = elem.getBoundingClientRect();
+      const left = pos.left > 300 ? pos.left - 235 : pos.left + pos.width + 10;
       return {
-        top: pos.top,
-        left: pos.left + 196,
+        top: Math.min(pos.top, window.innerHeight - 250),
+        left: left,
       };
     } else {
       return {
@@ -116,7 +117,14 @@ export class InputColor extends React.Component<InputColorProps> {
 
     return <div className="maputnik-color-wrapper">
       {this.state.pickerOpened && picker}
-      <div className="maputnik-color-swatch" style={swatchStyle}></div>
+      <input
+        type="color"
+        className="maputnik-color-swatch"
+        style={swatchStyle}
+        value={this.color.hex()}
+        onChange={(e) => this.onChange(e.target.value)}
+        title="Open color wheel"
+      />
       <input
         aria-label={this.props["aria-label"]}
         spellCheck="false"

--- a/src/styles/_components.scss
+++ b/src/styles/_components.scss
@@ -6,7 +6,8 @@
 .maputnik-map__container {
   background: white;
   display: flex;
-  width: vars.$layout-map-width;
+  flex: 1;
+  min-width: 0;
 
   &--error {
     align-items: center;
@@ -219,7 +220,8 @@
 
 // MESSAGE PANEL
 .maputnik-message-panel {
-  padding: vars.$margin-2;
+  padding: vars.$margin-2 vars.$margin-5 vars.$margin-2 vars.$margin-2;
+  position: relative;
 
   &-error {
     color: vars.$color-red;
@@ -229,6 +231,29 @@
     all: unset;
     text-decoration: underline;
     cursor: pointer;
+  }
+
+  &__close {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    right: vars.$margin-3;
+    background: transparent;
+    border: none;
+    color: vars.$color-lowgray;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: vars.$margin-1;
+    border-radius: 50%;
+    line-height: 1;
+    transition: color 0.2s, background-color 0.2s;
+
+    &:hover {
+      color: vars.$color-white;
+      background-color: rgba(255, 255, 255, 0.1);
+    }
   }
 }
 

--- a/src/styles/_input.scss
+++ b/src/styles/_input.scss
@@ -65,9 +65,26 @@
 
 .maputnik-color-swatch {
   height: 26px;
-  width: 14px;
+  width: 16px;
   flex-shrink: 0;
   flex-grow: 0;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  background: none;
+  outline: none;
+
+  &::-webkit-color-swatch-wrapper {
+    padding: 0;
+  }
+  &::-webkit-color-swatch {
+    border: none;
+    border-radius: 2px;
+  }
+  &::-moz-color-swatch {
+    border: none;
+    border-radius: 2px;
+  }
 }
 
 // ARRAY

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -28,9 +28,42 @@
     display: flex;
   }
 
+  &-sidebar {
+    display: flex;
+    overflow-x: auto;
+    overflow-y: hidden;
+    width: 200px;
+    flex-shrink: 0;
+    position: relative;
+    background-color: vars.$color-black;
+  }
+
+  &-resizer {
+    width: 6px;
+    background-color: vars.$color-midgray;
+    cursor: col-resize;
+    position: relative;
+    z-index: 100;
+    flex-shrink: 0;
+    transition: background-color 0.2s;
+
+    &:hover {
+      background-color: vars.$color-lowgray;
+    }
+  }
+
+  &--is-resizing {
+    user-select: none;
+
+    iframe, canvas, .maputnik-map__container {
+      pointer-events: none !important;
+    }
+  }
+
   &-list {
     width: 200px;
     background-color: vars.$color-black;
+    flex-shrink: 0;
   }
 
   &-drawer {
@@ -38,6 +71,7 @@
     background-color: vars.$color-black;
     // scroll-container is position: absolute
     position: relative;
+    flex-shrink: 0;
   }
 
   &-code-editor {
@@ -45,14 +79,15 @@
     background-color: vars.$color-black;
     // scroll-container is position: absolute
     position: relative;
+    flex-shrink: 0;
   }
 
   &-bottom {
     position: fixed;
     bottom: 0;
+    left: 200px;
     right: 0;
     z-index: 10;
-    width: vars.$layout-map-width;
     background-color: vars.$color-black;
   }
 }


### PR DESCRIPTION
1. Made the Editor Resizable & Scrollable:

Added a draggable splitter handle between the editor sidebar and the map.
Wrapped the editor panels in a horizontal scroll container so that if the sidebar is shrunk (reduced), you can scroll to see the layers list and details, increasing the map's visible viewport area.
Tied the bottom message panel's position dynamically to the sidebar's width to keep it aligned with the map.
Added a Bottom Panel Dismiss Button:

2. Added an "X" close button to the bottom message panel.
Allows dismissing the history/undo status messages (like "Undo removeLayer...") that appear on ctrl+z, clearing the panel.