### PR TITLE
ci: cancel superseded pull request runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
 
   build-node:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,10 @@ on:
   schedule:
     - cron: '17 0 * * 6'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
A push to an open pull request starts the build matrix and the jobs behind it again, and a second CodeQL analysis, while the previous run keeps going. This is the concurrency block the other maplibre repos use (maplibre-tile-spec, martin, maplibre-gl-js in maplibre/maplibre-gl-js#8317): pull request runs are keyed by number and cancelled when superseded; runs on the default branch queue behind each other and are never cancelled.

## Launch Checklist

 - [x] Briefly describe the changes in this PR.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section (not applicable, CI only).
