### PR TITLE
ci: keep the CodeQL actions on one version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
     cooldown:
       default-days: 3
       # no semver support for github-actions

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+      uses: github/codeql-action/autobuild@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+      uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9


### PR DESCRIPTION
CodeQL has been failing on main since #2105: `init` is on v4.37.9 while `autobuild` and `analyze` are on v4.37.8, and the action rejects a config written by a newer version ("Loaded a configuration file for version '4.37.9', but running version '4.37.8'"). Dependabot bumps the three steps in separate pull requests, so #2119 and #2120 each still fail on their own and main has gone red at every partial bump (08-19, 08-28, today).

This moves the two steps to v4.37.9, the same commit dependabot picked in #2119 and #2120, and groups `github/codeql-action*` in dependabot so the three bump together from now on. Supersedes #2119 and #2120.

## Launch Checklist

 - [x] Briefly describe the changes in this PR.
 - [ ] Add an entry to `CHANGELOG.md` under the `## main` section (not applicable, CI only).
